### PR TITLE
Too many changes to describe in one commit message

### DIFF
--- a/lifeapi_apps/base_app/models.py
+++ b/lifeapi_apps/base_app/models.py
@@ -10,8 +10,9 @@ class WebsiteFixTag(models.Model):
 
 class WebsiteFix(models.Model):
     STATUS_CHOICES = (
-        ('Fixed', 'Fixed'),
+        ('Done', 'Done'),
         ('Not Fixed', 'Not Fixed'),
+        ('In Progress', 'In Progress'),
     )
 
     title = models.CharField(max_length=100)

--- a/lifeapi_apps/base_app/templates/base.html
+++ b/lifeapi_apps/base_app/templates/base.html
@@ -9,6 +9,8 @@
     <link rel="stylesheet" href="{% static 'global.css' %}">
     <!-- Datatables CSS -->
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.5/css/dataTables.bootstrap5.min.css">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
 <body>

--- a/lifeapi_apps/base_app/templates/base.html
+++ b/lifeapi_apps/base_app/templates/base.html
@@ -82,6 +82,7 @@
         searching: true,
         bInfo: true,
         bSort: true,
+        order: [[0, 'desc']],
 
         // Disable A to Z, Z to A in actions column
         "columnDefs": [{

--- a/lifeapi_apps/base_app/templates/website_fixes/add_website_fix.html
+++ b/lifeapi_apps/base_app/templates/website_fixes/add_website_fix.html
@@ -8,7 +8,7 @@
         <form method="post">
             {% csrf_token %}
             {{ form.as_p }}
-            <button type="submit" class="btn btn-primary">Save Changes</button>
+            <button type="submit" class="btn btn-primary">Add new fix</button>
         </form>
     </div>
 {% endblock %}

--- a/lifeapi_apps/base_app/templates/website_fixes/preview_website_fix.html
+++ b/lifeapi_apps/base_app/templates/website_fixes/preview_website_fix.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <div class="container mt-4">
+        <h1>Preview Website Fix</h1>
+
+        <table class="table">
+            <tbody>
+                <tr>
+                    <th>Title:</th>
+                    <td>{{ fix.title }}</td>
+                </tr>
+                <tr>
+                    <th>Description:</th>
+                    <td>{{ fix.description }}</td>
+                </tr>
+                <tr>
+                    <th>Status:</th>
+                    <td>{{ fix.status }}</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <form method="post">
+            {% csrf_token %}
+            <a href="{% url 'edit_website_fix' fix.id %}" type="submit" class="btn btn-danger">Edit</a>
+            <a href="{% url 'website_fixes' %}" class="btn btn-secondary">Back</a>
+        </form>
+    </div>
+{% endblock %}

--- a/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
+++ b/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
@@ -36,11 +36,11 @@
                             {% endfor %}
                         </td>
                         <td>
-                            <a href="{% url 'delete_website_fix' fix.id %}" class="btn btn-sm btn-danger">
-                                <i class="fas fa-times"></i>
-                            </a>
                             <a href="{% url 'edit_website_fix' fix.id %}" class="btn btn-sm btn-info">
                                 <i class="fas fa-pencil-alt"></i>
+                            </a>
+                            <a href="{% url 'delete_website_fix' fix.id %}" class="btn btn-sm btn-danger">
+                                <i class="fas fa-times"></i>
                             </a>
                         </td>
                     </tr>

--- a/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
+++ b/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
@@ -35,7 +35,12 @@
                             {% endfor %}
                         </td>
                         <td>
-                            <a href="{% url 'delete_website_fix' fix.id %}" class="btn btn-sm btn-danger">Delete</a>
+                            <a href="{% url 'delete_website_fix' fix.id %}" class="btn btn-sm btn-danger">
+                                <i class="fas fa-times"></i>
+                            </a>
+                            <a href="{% url 'edit_website_fix' fix.id %}" class="btn btn-sm btn-info">
+                                <i class="fas fa-pencil-alt"></i>
+                            </a>
                         </td>
                     </tr>
                 {% empty %}

--- a/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
+++ b/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
@@ -19,12 +19,13 @@
             <tbody>
                 {% for fix in fixes %}
                     <tr>
-                        <td>{{ fix.date_created|date:"Y-m-d" }}</td>
-                        <td><a class="text-dark" href="{% url 'edit_website_fix' fix.id %}">{{ fix.title }}</a></td>
                         <td>{{ fix.date_created|date:"Y-m-d" }} {{ fix.date_created|time:"H:i" }}</td>
+                        <td><a class="text-dark" href="{% url 'preview_website_fix' fix.id %}">{{ fix.title }}</a></td>
                         <td>
-                            {% if fix.status == 'Fixed' %}
+                            {% if fix.status == 'Done' %}
                                 <span class="badge badge-success">{{ fix.status }}</span>
+                            {% elif fix.status == 'In Progress' %}
+                                <span class="badge badge-warning">{{ fix.status }}</span>
                             {% else %}
                                 <span class="badge badge-danger">{{ fix.status }}</span>
                             {% endif %}

--- a/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
+++ b/lifeapi_apps/base_app/templates/website_fixes/website_fixes.html
@@ -21,6 +21,7 @@
                     <tr>
                         <td>{{ fix.date_created|date:"Y-m-d" }}</td>
                         <td><a class="text-dark" href="{% url 'edit_website_fix' fix.id %}">{{ fix.title }}</a></td>
+                        <td>{{ fix.date_created|date:"Y-m-d" }} {{ fix.date_created|time:"H:i" }}</td>
                         <td>
                             {% if fix.status == 'Fixed' %}
                                 <span class="badge badge-success">{{ fix.status }}</span>

--- a/lifeapi_apps/base_app/urls.py
+++ b/lifeapi_apps/base_app/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('website-fixes/add', views.add_website_fix, name='add_website_fix'),
     path('website-fixes/<int:fix_id>/edit/', views.edit_website_fix, name='edit_website_fix'),
     path('website-fixes/<int:fix_id>/delete/', views.delete_website_fix, name='delete_website_fix'),
+    path('website-fixes/<int:fix_id>/preview/', views.preview_website_fix, name='preview_website_fix'),
 ]

--- a/lifeapi_apps/base_app/views.py
+++ b/lifeapi_apps/base_app/views.py
@@ -8,7 +8,7 @@ def home(request):
 
 
 def website_fixes(request):
-    fixes = WebsiteFix.objects.all().order_by('-date_created')
+    fixes = WebsiteFix.objects.all()
 
     context = {
         'fixes': fixes,

--- a/lifeapi_apps/base_app/views.py
+++ b/lifeapi_apps/base_app/views.py
@@ -33,6 +33,16 @@ def add_website_fix(request):
     return render(request, 'website_fixes/add_website_fix.html', context)
 
 
+def preview_website_fix(request, fix_id):
+    fix = get_object_or_404(WebsiteFix, id=fix_id)
+    
+    context = {
+        'fix': fix,
+    }
+
+    return render(request, 'website_fixes/preview_website_fix.html', context)
+
+
 def edit_website_fix(request, fix_id):
     fix = get_object_or_404(WebsiteFix, id=fix_id)
 


### PR DESCRIPTION
- order website fixes by newest with jquery datatable instead of python order_by
- by default datatable orders other way around, so removing python way
- website fix entry show date + time
- change choices for website fix
- Icons for website fix edit/delete buttons
- Created a possibility to preview the fix
- Changed the order of edit/delete buttons