### PR TITLE
If there's no corresponding answer, add an empty answer

### DIFF
--- a/lifeapi_apps/quiz_app/views.py
+++ b/lifeapi_apps/quiz_app/views.py
@@ -144,6 +144,12 @@ def data_table_test(request):
                     'description': question.description,
                     'answer': corresponding_answer.answer,
                 })
+            else:
+            # If there's no corresponding answer, add an empty answer
+                matching_answers.append({
+                'description': question.description,
+                'answer': '',
+            })
 
         if matching_answers:
             data_to_display.append({


### PR DESCRIPTION
- so datatables dont get angry about "18. Incorrect column count" rule
- I can now create new questions and they will imeadietelly get prefilled with empty column entries, which will result in nicely rendered table