### PR TITLE
sort answers by year-month-date

### DIFF
--- a/lifeapi_apps/quiz_app/templates/data_table.html
+++ b/lifeapi_apps/quiz_app/templates/data_table.html
@@ -27,7 +27,7 @@
       <tr>
         <!-- https://docs.djangoproject.com/en/dev/ref/templates/builtins/?from=olddocs#date -->
         <!-- <td>{{ entry.date|date:"m-d" }}, {{ entry.date|date:"D" }}</td> -->
-        <td>{{ entry.date|date:"m-d" }}</td>
+        <td>{{ entry.date|date:"Y-m-d" }}</td>
         <td>{{ entry.temperature }}</td>
         <td>{{entry.productive_hours|default:""}}</td>
         <td>{{ entry.distracting_hours|default:"" }}</td>


### PR DESCRIPTION
new year would break the current sorting. It would but 01-01 (january first) to the end of the list, when it should be first. 01-01 should be AFTER 12-29